### PR TITLE
re-instated imagehash copyright notice following the BSD license

### DIFF
--- a/scanner/hashFile.py
+++ b/scanner/hashFile.py
@@ -1,3 +1,15 @@
+"""
+Copyright (c) 2013-2016, Johannes Buchner
+Copyright (c) 2016, Connor Wolf
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
 
 from PIL import Image
 
@@ -7,6 +19,7 @@ import hashlib
 
 import scanner.unitConverters
 
+# code from imagehash https://github.com/JohannesBuchner/imagehash
 from PIL import Image
 import numpy
 import scipy.fftpack


### PR DESCRIPTION
I am happy that you chose to use source code I wrote. That is what open source is all about. But please respect the BSD license, which only requests only two things - a copyright notice and warranty disclaimers. This commit re-instates these for the file hashFile.py.
Alternatively, you can import the module imagehash (it is in pypi) through setup.py and through that always get the latest version.